### PR TITLE
Allow to bind to different host/ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ You can use the following config options:
 ```javascript
 {
   "appName": "elastalert-server", // The name used by the logging framework.
+  "host": '0.0.0.0' // The host to bind to
   "port": 3030, // The port to bind to
+  "wshost": '0.0.0.0' // The host to bind to for websockets
   "wsport": 3333, // The port to bind to for websockets
   "elastalertPath": "/opt/elastalert",  // The path to the root ElastAlert folder. It's the folder that contains the `setup.py` script.
   "start": "2014-01-01T00:00:00", // Optional date to start querying from

--- a/src/common/config/schema.js
+++ b/src/common/config/schema.js
@@ -6,7 +6,10 @@ const schema = Joi.object().keys({
   'es_host': Joi.string().default('elastalert'),
   'es_port': Joi.number().default(9200),
   'writeback_index': Joi.string().default('elastalert_status'),
+  'host': Joi.string().default('0.0.0.0'),
   'port': Joi.number().default(3030),
+  'wshost': Joi.string().default('0.0.0.0'),
+  'wsport': Joi.number().default(3333),
   'elastalertPath': Joi.string().default('/opt/elastalert'),
   'rulesPath': Joi.object().keys({
     'relative': Joi.boolean().default(true),

--- a/src/common/websocket.js
+++ b/src/common/websocket.js
@@ -2,8 +2,8 @@ import WebSocket from 'ws';
 
 export var wss = null;
 
-export function listen(port) {
-  wss = new WebSocket.Server({ port, path: '/test' });
+export function listen(port, host) {
+  wss = new WebSocket.Server({ port: port, host: host, path: '/test' });
 
   wss.on('connection', ws => {
     ws.isAlive = true;
@@ -16,7 +16,7 @@ export function listen(port) {
 }
 
 // Keepalive in case clients lose connection during a long rule test.
-// If client doesn't respond in 10s this will close the socket and 
+// If client doesn't respond in 10s this will close the socket and
 // therefore stop the elastalert test from continuing to run detached.
 setInterval(() => {
   wss.clients.forEach(ws => {

--- a/src/elastalert_server.js
+++ b/src/elastalert_server.js
@@ -81,7 +81,7 @@ export default class ElastalertServer {
         self._express.use(bodyParser.json());
         self._express.use(bodyParser.urlencoded({ extended: true }));
         self._setupRouter();
-        self._runningServer = self.express.listen(config.get('port'), self._serverController);
+        self._runningServer = self.express.listen(config.get('port'), config.get('host'), self._serverController);
         self._express.set('server', self);
 
         self._fileSystemController = new FileSystem();
@@ -102,10 +102,10 @@ export default class ElastalertServer {
         self._fileSystemController.createDirectoryIfNotExists(self.getDataFolder()).catch(function (error) {
           logger.error('Error creating data folder with error:', error);
         });
-        
-        logger.info('Server listening on port ' + config.get('port'));
 
-        let wss = listen(config.get('wsport'));
+        logger.info('Server listening on ' + config.get('host') + ':' + config.get('port'));
+
+        let wss = listen(config.get('wsport'), config.get('wshost'));
 
         wss.on('connection', ws => {
           ws.on('message', (data) => {
@@ -122,7 +122,7 @@ export default class ElastalertServer {
           });
         });
 
-        logger.info('Websocket listening on port 3333');
+        logger.info('Websocket listening on ' + config.get('wshost') + ':' + config.get('wsport'));
       } catch (error) {
         logger.error('Starting server failed with error:', error);
         process.exit(1);


### PR DESCRIPTION
By default, it's bound to `:::` and not convenient if you have multiple interfaces and would like to use different port for different interface.