### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY patches/alerts.py /opt/elastalert/elastalert/alerts.py
 RUN mkdir -p /opt/elastalert/rules/ /opt/elastalert/server_data/tests/ \
     && chown -R node:node /opt
 
-RUN pip3 install --upgrade pip
+RUN pip3 install --no-cache-dir --upgrade pip
 
 USER node
 
@@ -63,7 +63,7 @@ RUN sed -i 's/jira>=1.0.10,<1.0.15/jira>=2.0.0/g' requirements.txt && \
     sed -i 's/py-zabbix==1.1.3/py-zabbix>=1.1.3/g' requirements.txt && \
     sed -i 's/requests>=2.0.0/requests>=2.10.0/g' requirements.txt && \
     sed -i 's/twilio==6.0.0/twilio>=6.0.0,<6.1/g' requirements.txt && \
-    pip3 install -r requirements.txt --user
+    pip3 install --no-cache-dir -r requirements.txt --user
 
 WORKDIR /opt/elastalert-server
 


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>