### PR TITLE
added  hour_range_enhancement in order to use time window feature

### DIFF
--- a/elastalert_modules/hour_range_enhancement.py
+++ b/elastalert_modules/hour_range_enhancement.py
@@ -1,0 +1,26 @@
+import dateutil.parser
+
+from elastalert.enhancements import BaseEnhancement
+from elastalert.enhancements import DropMatchException
+
+
+class HourRangeEnhancement(BaseEnhancement):
+    def process(self, match):
+        timestamp = None
+        try:
+            timestamp = dateutil.parser.parse(match['@timestamp']).time()
+        except Exception:
+            try:
+                timestamp = dateutil.parser.parse(match[self.rule['timestamp_field']]).time()
+            except Exception:
+                pass
+        if timestamp is not None:
+            time_start = dateutil.parser.parse(self.rule['start_time']).time()
+            time_end = dateutil.parser.parse(self.rule['end_time']).time()
+            if(self.rule['drop_if'] == 'outside'):
+                if timestamp < time_start or timestamp > time_end:
+                    raise DropMatchException()
+            elif(self.rule['drop_if'] == 'inside'):
+                if timestamp >= time_start and timestamp <= time_end:
+                    raise DropMatchException()
+


### PR DESCRIPTION
Hi @johnsusek 
My name is Abir and I am working with Praeco in my company (I am working with @osherdp if you remember him).
We wanted to send alerts only at ranged time during the day, so we developed a feature for Praeco.
The feature is called Time Window and the user can use it to send alerts only during specific time range.

I opened a pull request for Praeco: https://github.com/johnsusek/praeco/pull/301
The feature in the mentioned pull request depends on the enhancement I added to elastalert_module in elastalert.
Please review the changes and merge it to Praeco so everyone will be able to use it.

Credits:
@abirsigron - my presonal account
@0xSeb for writing the enhancement: https://github.com/0xSeb/elastalert_hour_range
