### PR TITLE
fix getClientVersion when opensearch_flg is set

### DIFF
--- a/src/common/elasticsearch_client.js
+++ b/src/common/elasticsearch_client.js
@@ -44,7 +44,7 @@ export async function getClientVersion() {
   try {
     // OpenSearch 1.0
     if (config.get('opensearch_flg')) {
-      return '7.10.2';
+      return '7';
     }
 
     let scheme = 'http';


### PR DESCRIPTION
this PR fixes the getClientVersion function when the opensearch_flg is set.

the client version is expected to be a single digit (see line 85) and was causing some search operations to return 0 results (specifically, the metadata queries)

alternatively, this hard-coded version number can be removed if the user sets the `compatibility.override_main_response_version: true` option in their opensearch config.