### PR TITLE
Fix 404 for rules, templates, folders and silence in subfolders (Express 5 routes)

### DIFF
--- a/src/handlers/folders/delete.js
+++ b/src/handlers/folders/delete.js
@@ -8,9 +8,7 @@ export default function folderDeleteHandler(request, response) {
    * @type {ElastalertServer}
    */
   let server = request.app.get('server');
-  let pathParts = request.originalUrl.split('/');
-  let pathIndex = pathParts.indexOf(request.params.type) + 1;
-  let path = pathParts.slice(pathIndex).join('/');
+  let path = request.params.path.join('/');
 
   server.foldersController.delete(request.params.type, path)
     .then(function () {

--- a/src/handlers/folders/put.js
+++ b/src/handlers/folders/put.js
@@ -8,9 +8,7 @@ export default function folderPostHandler(request, response) {
    * @type {ElastalertServer}
    */
   let server = request.app.get('server');
-  let pathParts = request.originalUrl.split('/');
-  let pathIndex = pathParts.indexOf(request.params.type) + 1;
-  let path = pathParts.slice(pathIndex).join('/');
+  let path = request.params.path.join('/');
 
   server.foldersController.create(request.params.type, path)
     .then(function () {

--- a/src/handlers/rules/id/delete.js
+++ b/src/handlers/rules/id/delete.js
@@ -8,9 +8,7 @@ export default function ruleDeleteHandler(request, response) {
    * @type {ElastalertServer}
    */
   let server = request.app.get('server');
-  let pathParts = request.originalUrl.split('/');
-  let idIndex = pathParts.indexOf('rules') + 1;
-  let path = pathParts.slice(idIndex).join('/');
+  let path = request.params.id.join('/');
 
   server.rulesController.rule(path)
     .then(function (rule) {

--- a/src/handlers/rules/id/get.js
+++ b/src/handlers/rules/id/get.js
@@ -9,9 +9,7 @@ export default function ruleGetHandler(request, response) {
    */
   let server = request.app.get('server');
 
-  let pathParts = request.originalUrl.split('/');
-  let idIndex = pathParts.indexOf('rules') + 1;
-  let path = pathParts.slice(idIndex).join('/');
+  let path = request.params.id.join('/');
   
   server.rulesController.rule(path)
     .then(function (rule) {

--- a/src/handlers/rules/id/post.js
+++ b/src/handlers/rules/id/post.js
@@ -9,9 +9,7 @@ export default function rulePostHandler(request, response) {
    */
   let server = request.app.get('server');
   let body = request.body ? request.body.yaml : undefined;
-  let pathParts = request.originalUrl.split('/');
-  let idIndex = pathParts.indexOf('rules') + 1;
-  let path = pathParts.slice(idIndex).join('/');
+  let path = request.params.id.join('/');
 
   server.rulesController.rule(path)
     .then(function (rule) {

--- a/src/handlers/silence/post.js
+++ b/src/handlers/silence/post.js
@@ -40,9 +40,7 @@ export default function silencePostHandler(request, response) {
     sendRequestError(response, body.error);
   }
 
-  let pathParts = request.originalUrl.split('/');
-  let pathIndex = pathParts.indexOf('silence') + 1;
-  let path = pathParts.slice(pathIndex).join('/');
+  let path = request.params.path.join('/');
 
   server.silenceController.silenceRule(path, body.unit, body.duration)
     .then(function (consoleOutput) {

--- a/src/handlers/templates/id/delete.js
+++ b/src/handlers/templates/id/delete.js
@@ -8,9 +8,7 @@ export default function templateDeleteHandler(request, response) {
    * @type {ElastalertServer}
    */
   let server = request.app.get('server');
-  let pathParts = request.originalUrl.split('/');
-  let idIndex = pathParts.indexOf('templates') + 1;
-  let path = pathParts.slice(idIndex).join('/');
+  let path = request.params.id.join('/');
 
   server.templatesController.template(path)
     .then(function (template) {

--- a/src/handlers/templates/id/get.js
+++ b/src/handlers/templates/id/get.js
@@ -8,9 +8,7 @@ export default function templateGetHandler(request, response) {
    * @type {ElastalertServer}
    */
   let server = request.app.get('server');
-  let pathParts = request.originalUrl.split('/');
-  let idIndex = pathParts.indexOf('templates') + 1;
-  let path = pathParts.slice(idIndex).join('/');
+  let path = request.params.id.join('/');
 
   server.templatesController.template(path)
     .then(function (template) {

--- a/src/handlers/templates/id/post.js
+++ b/src/handlers/templates/id/post.js
@@ -9,9 +9,7 @@ export default function templatePostHandler(request, response) {
    */
   let server = request.app.get('server');
   let body = request.body ? request.body.yaml : undefined;
-  let pathParts = request.originalUrl.split('/');
-  let idIndex = pathParts.indexOf('templates') + 1;
-  let path = pathParts.slice(idIndex).join('/');
+  let path = request.params.id.join('/');
 
   server.templatesController.template(path)
     .then(function (template) {

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -58,7 +58,7 @@ let routes = [
     method: 'GET',
     handler: rulesHandler
   }, {
-    path: 'rules/:id',
+    path: 'rules/*id',
     method: ['GET', 'POST', 'DELETE'],
     handler: [ruleGetHandler, rulePostHandler, ruleDeleteHandler]
   }, {
@@ -67,11 +67,11 @@ let routes = [
     handler: templatesHandler
   }, {
     method: ['GET', 'POST', 'DELETE'],
-    path: 'templates/:id',
+    path: 'templates/*id',
     handler: [templateGetHandler, templatePostHandler, templateDeleteHandler]
   }, 
   { 
-    path: 'folders/:type/:path',
+    path: 'folders/:type/*path',
     method: ['PUT', 'DELETE'],
     handler: [folderPutHandler, folderDeleteHandler]
   },
@@ -81,7 +81,7 @@ let routes = [
     handler: testPostHandler
   }, 
   {
-    path: 'silence/:path',
+    path: 'silence/*path',
     method: 'POST',
     handler: silencePostHandler
   }, 


### PR DESCRIPTION
> [!NOTE]
> **AI disclosure:** This fix was developed with the help of an AI assistant (Claude Code by Anthropic). The AI analyzed the regression, authored the code changes and this PR description. The changes were reviewed and the fix was verified end-to-end against a running server by a human maintainer before submission.

## Problem

Since the Express 4 to 5 migration (02cc6f15eeac5ba56b002cb61e9744078bc7174b), any rule, template, folder or silence target located inside a subfolder returns **404**.

Express 5 (path-to-regexp v8) removed the `:id*` repeat syntax, and the migration replaced `rules/:id*` with `rules/:id`, which matches only a **single** path segment. So `GET /rules/myfolder/myrule` no longer matches any route and Express returns 404 before the handler even runs. The `request.originalUrl.split('/')` parsing added to the handlers in that commit is unreachable for those paths, and buggy even for single-segment paths (query strings leak into the rule path and segments are never URL-decoded).

## Fix

- Use Express 5 named wildcards, which match one or more segments: `rules/*id`, `templates/*id`, `folders/:type/*path`, `silence/*path`.
- In the handlers, read the path from the wildcard param, which Express 5 provides as an array of already-decoded segments: `request.params.id.join('/')`. This replaces the `originalUrl` parsing and also fixes the query-string and URL-decoding issues.

## Testing

Verified end-to-end against a running server:

- `GET /rules` listing still works, as do single-segment rules (`GET /rules/myrule`).
- `GET /rules/dir/subdir/myrule` and `GET /templates/tdir/mytemplate` return the YAML instead of 404.
- `PUT /folders/rules/newdir/sub`, `POST /rules/newdir/sub/newrule`, `DELETE /rules/newdir/sub/newrule` and `DELETE /folders/rules/newdir` all work on nested paths.
- `POST /silence/dir/subdir/myrule` invokes elastalert with the correctly resolved `--rule .../rules/dir/subdir/myrule.yaml`.
- Query strings and URL-encoded segments (`/rules/dir/my%20rule`) now resolve correctly.
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
